### PR TITLE
Include "visibility.h" in gles2.c

### DIFF
--- a/src/platform/render/gles2.c
+++ b/src/platform/render/gles2.c
@@ -7,6 +7,7 @@
 #include <wayland-server.h>
 #include <chck/string/string.h>
 #include "internal.h"
+#include "visibility.h"
 #include "gles2.h"
 #include "render.h"
 #include "platform/context/egl.h"


### PR DESCRIPTION
Shit not compilable without it.